### PR TITLE
[Bugfix] -  Correctly Implement Empty Type Code Skip

### DIFF
--- a/bai2/__init__.py
+++ b/bai2/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (0, 15, 0)
+VERSION = (0, 15, 1)
 __version__ = ".".join(map(str, VERSION))

--- a/bai2/utils.py
+++ b/bai2/utils.py
@@ -70,14 +70,11 @@ def write_military_time(time):
 
 def parse_type_code(value):
     try:
-        return TypeCodes[value]
+        return TypeCodes[value.strip() if value else ""]
     except KeyError as exc:
-        if value == "":
-            return ""
-        else:
-            raise NotSupportedYetException(
-                f"Type code {value!r} is not supported yet"
-            ) from exc
+        raise NotSupportedYetException(
+            f"Type code {value!r} is not supported yet"
+        ) from exc
 
 
 def convert_to_string(value):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,15 @@
 import datetime
 from unittest import TestCase
 
-from bai2.utils import parse_date, parse_military_time, parse_time, write_time
+from bai2.constants import TypeCodes
+from bai2.exceptions import NotSupportedYetException
+from bai2.utils import (
+    parse_date,
+    parse_military_time,
+    parse_time,
+    parse_type_code,
+    write_time,
+)
 
 
 class ParseDateTestCase(TestCase):
@@ -89,3 +97,24 @@ class WriteTime(TestCase):
 
         str_value = write_time(time, True)
         self.assertEqual(str_value, "2400")
+
+
+class TestParseTypeCode(TestCase):
+    def test_parse_type_code(self):
+        parsed_value = parse_type_code("165")
+        self.assertEqual(TypeCodes["165"], parsed_value)
+
+    def test_parse_type_code_with_empty_string(self):
+        parsed_value = parse_type_code("")
+        self.assertEqual(TypeCodes[""], parsed_value)
+
+    def test_parse_type_code_with_none(self):
+        parsed_value = parse_type_code(None)
+        self.assertEqual(TypeCodes[""], parsed_value)
+
+    def test_parse_type_code_with_whitespace(self):
+        parsed_value = parse_type_code("  165  ")
+        self.assertEqual(TypeCodes["165"], parsed_value)
+
+    def test_parse_type_code_with_invalid_type_code(self):
+        self.assertRaises(NotSupportedYetException, parse_type_code, "ABC")


### PR DESCRIPTION
1. Changes the utility function `parse_type_code()` in `bai2.utilities` based on the discussion on this comment: https://github.com/balance-cash/bai2/pull/8#discussion_r2627786687
2. Adds relevant tests for the new functionality
3. Increments the version from 0.15.0 to 0.15.1 in order to have a new release created after merging.