### PR TITLE
BAL-8258: Add 4 Digit Year Parsing Support to BAI2 Library

### DIFF
--- a/bai2/__init__.py
+++ b/bai2/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (0, 15, 2)
+VERSION = (0, 15, 3)
 __version__ = ".".join(map(str, VERSION))

--- a/bai2/utils.py
+++ b/bai2/utils.py
@@ -9,13 +9,28 @@ def parse_date(value):
     """
     YYMMDD with a fallback to YYYYMMDD Format.
     """
-    try:
-        return datetime.datetime.strptime(value, "%y%m%d").date()
-    except ValueError:
+    length = parse_date_length(value)
+    if length == 6:
+        try:
+            return datetime.datetime.strptime(value, "%y%m%d").date()
+        except ValueError as err:
+            raise NotSupportedYetException(f"Date {value!r} is not supported") from err
+    elif length == 8:
         try:
             return datetime.datetime.strptime(value, "%Y%m%d").date()
         except ValueError as err:
             raise NotSupportedYetException(f"Date {value!r} is not supported") from err
+    else:
+        raise NotSupportedYetException(f"Date {value!r} is not supported")
+
+
+def parse_date_length(value) -> int:
+    if len(value) == 6 or len(value) == 8:
+        return len(value)
+    else:
+        raise NotSupportedYetException(
+            f"Dates with length {len(value)} are not supported"
+        )
 
 
 def write_date(date):

--- a/bai2/utils.py
+++ b/bai2/utils.py
@@ -19,13 +19,7 @@ def parse_date(value):
 
 
 def write_date(date):
-    try:
-        return date.strftime("%y%m%d")
-    except ValueError:
-        try:
-            return date.strftime("%Y%m%d")
-        except ValueError as err:
-            raise NotSupportedYetException(f"Date {date!r} is not supported") from err
+    return date.strftime("%y%m%d")
 
 
 def parse_time(value):

--- a/bai2/utils.py
+++ b/bai2/utils.py
@@ -7,13 +7,25 @@ from .exceptions import NotSupportedYetException
 
 def parse_date(value):
     """
-    YYMMDD Format.
+    YYMMDD with a fallback to YYYYMMDD Format.
     """
-    return datetime.datetime.strptime(value, "%y%m%d").date()
+    try:
+        return datetime.datetime.strptime(value, "%y%m%d").date()
+    except ValueError:
+        try:
+            return datetime.datetime.strptime(value, "%Y%m%d").date()
+        except ValueError as err:
+            raise NotSupportedYetException(f"Date {value!r} is not supported") from err
 
 
 def write_date(date):
-    return date.strftime("%y%m%d")
+    try:
+        return date.strftime("%y%m%d")
+    except ValueError:
+        try:
+            return date.strftime("%Y%m%d")
+        except ValueError as err:
+            raise NotSupportedYetException(f"Date {date!r} is not supported") from err
 
 
 def parse_time(value):

--- a/bai2/utils.py
+++ b/bai2/utils.py
@@ -15,21 +15,21 @@ def parse_date(value):
             return datetime.datetime.strptime(value, "%y%m%d").date()
         except ValueError as err:
             raise NotSupportedYetException(f"Date {value!r} is not supported") from err
-    elif length == 8:
+    else:
+        # try to parse as YYYYMMDD, else raise exception
         try:
             return datetime.datetime.strptime(value, "%Y%m%d").date()
         except ValueError as err:
             raise NotSupportedYetException(f"Date {value!r} is not supported") from err
-    else:
-        raise NotSupportedYetException(f"Date {value!r} is not supported")
 
 
 def parse_date_length(value) -> int:
-    if len(value) == 6 or len(value) == 8:
-        return len(value)
+    date_length = len(value)
+    if date_length == 6 or date_length == 8:
+        return date_length
     else:
         raise NotSupportedYetException(
-            f"Dates with length {len(value)} are not supported"
+            f"Dates with length {date_length} are not supported"
         )
 
 

--- a/bai2/utils.py
+++ b/bai2/utils.py
@@ -29,7 +29,8 @@ def parse_date_length(value) -> int:
         return date_length
     else:
         raise NotSupportedYetException(
-            f"Dates with length {date_length} are not supported"
+            f"Date {value!r} has unsupported length {date_length}; "
+            "expected 6 (YYMMDD) or 8 (YYYYMMDD)"
         )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,10 @@ class ParseDateTestCase(TestCase):
             parsed,
         )
 
-    def test_parse_invalid_date(self):
+    def test_parse_invalid_date_6_digit(self):
+        self.assertRaises(NotSupportedYetException, parse_date, "161332")
+
+    def test_parse_invalid_date_8_digit(self):
         self.assertRaises(NotSupportedYetException, parse_date, "20161332")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,16 @@ class ParseDateTestCase(TestCase):
             parsed,
         )
 
+    def test_parse_4_digit_year(self):
+        parsed = parse_date("20160331")
+        self.assertEqual(
+            datetime.date(year=2016, month=3, day=31),
+            parsed,
+        )
+
+    def test_parse_invalid_date(self):
+        self.assertRaises(NotSupportedYetException, parse_date, "20161332")
+
 
 class ParseTimeTestCase(TestCase):
     def test_clock_time(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,9 +5,11 @@ from bai2.constants import TypeCodes
 from bai2.exceptions import NotSupportedYetException
 from bai2.utils import (
     parse_date,
+    parse_date_length,
     parse_military_time,
     parse_time,
     parse_type_code,
+    write_date,
     write_time,
 )
 
@@ -32,6 +34,17 @@ class ParseDateTestCase(TestCase):
 
     def test_parse_invalid_date_8_digit(self):
         self.assertRaises(NotSupportedYetException, parse_date, "20161332")
+
+    def test_parse_date_length(self):
+        self.assertEqual(parse_date_length("160331"), 6)
+        self.assertEqual(parse_date_length("20160331"), 8)
+        self.assertRaises(NotSupportedYetException, parse_date_length, "1603312")
+        self.assertRaises(NotSupportedYetException, parse_date_length, "160331234")
+        self.assertRaises(NotSupportedYetException, parse_date_length, "1603312345")
+        self.assertRaises(NotSupportedYetException, parse_date_length, "16033123456")
+        self.assertRaises(NotSupportedYetException, parse_date_length, "160331234567")
+        self.assertRaises(NotSupportedYetException, parse_date_length, "1603312345678")
+        self.assertRaises(NotSupportedYetException, parse_date_length, "16033123456789")
 
 
 class ParseTimeTestCase(TestCase):
@@ -84,6 +97,13 @@ class ParseMilitaryTime(TestCase):
             datetime.time(hour=0, minute=0),
             parsed_value,
         )
+
+
+class WriteDate(TestCase):
+    def test_write(self):
+        date = datetime.date(year=2016, month=3, day=31)
+        str_value = write_date(date)
+        self.assertEqual(str_value, "160331")
 
 
 class WriteTime(TestCase):


### PR DESCRIPTION
1. Adds support for parsing dates with years indicated in 4 digits.
2. Increments the library version from 0.15.2 to 0.15.3